### PR TITLE
[BE/feat]: 공통 응답/예외/설정 모듈 초기 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("org.postgresql:postgresql")

--- a/backend/src/main/java/com/travel/taipei/global/config/RedisConfig.java
+++ b/backend/src/main/java/com/travel/taipei/global/config/RedisConfig.java
@@ -1,0 +1,28 @@
+package com.travel.taipei.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        return template;
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/global/config/WebClientConfig.java
+++ b/backend/src/main/java/com/travel/taipei/global/config/WebClientConfig.java
@@ -1,0 +1,14 @@
+package com.travel.taipei.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        return WebClient.builder().build();
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/global/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/travel/taipei/global/config/WebMvcConfig.java
@@ -1,0 +1,15 @@
+package com.travel.taipei.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/global/exception/BusinessException.java
+++ b/backend/src/main/java/com/travel/taipei/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.travel.taipei.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/travel/taipei/global/exception/ErrorCode.java
@@ -1,0 +1,24 @@
+package com.travel.taipei.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // Phrase
+    PHRASE_NOT_FOUND(HttpStatus.NOT_FOUND, "PH001", "해당 문구를 찾을 수 없습니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "PH002", "유효하지 않은 카테고리입니다."),
+
+    // External API
+    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "EX001", "외부 API 호출에 실패했습니다."),
+
+    // Common
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "CM001", "잘못된 요청입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/backend/src/main/java/com/travel/taipei/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/travel/taipei/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,37 @@
+package com.travel.taipei.global.exception;
+
+import com.travel.taipei.global.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ApiResponse.fail(errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .findFirst()
+                .orElse(ErrorCode.INVALID_INPUT.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT.getStatus())
+                .body(ApiResponse.fail(message));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        return ResponseEntity
+                .internalServerError()
+                .body(ApiResponse.fail("서버 오류가 발생했습니다."));
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/travel/taipei/global/response/ApiResponse.java
@@ -1,0 +1,18 @@
+package com.travel.taipei.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        T data,
+        String message
+) {
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(String message) {
+        return new ApiResponse<>(false, null, message);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,5 +18,10 @@ spring:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
 
+external:
+  exchange:
+    api-key: ${EXCHANGE_API_KEY}
+    url: https://www.koreaexim.go.kr/site/program/financial/exchangeJSON
+
 server:
   port: 8080


### PR DESCRIPTION
## 관련 이슈
closes #2 

## 변경 사항
<!-- 무엇을 변경했는지 간결하게 -->
백엔드에서 공통으로 사용할 수 있는 응답 형식, 예외 처리, 설정 모듈을 초기 구현했습니다.

📁 구현 방향 
- `global/response/ApiResponse` → 공통 API 응답 포맷 (successm data, message)
- `global/exception/ErrorCode` → 에러 코드 enum 중앙 관리 
- `global/exception/BusinessException` → 커스텀 런타임 예외
- `global/exception/GlobalExceptionHandler` → @RestControllerAdvice 전역 예외 처리 
- `global/config/RedisConfig` → RedisTemplate Bean 등록 
- `global/config/WebClientConfig` → WebCliend Bean 등록 
- `global/config/WebMvcConfig` → CORS 전역 설정

## 변경 유형
- [✓] feat: 새 기능
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] chore: 빌드/설정 변경
- [ ] docs: 문서

## 체크리스트
- [✓] 로컬에서 정상 동작 확인
- [ ] 테스트 추가/수정
- [ ] API 변경 시 프론트엔드 반영 확인