### PR TITLE
[BE/feat] 대만어 회화 API 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testRuntimeOnly("com.h2database:h2")
 }
 
 tasks.withType<Test> {

--- a/backend/src/main/java/com/travel/taipei/phrase/application/PhraseService.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/application/PhraseService.java
@@ -1,0 +1,51 @@
+package com.travel.taipei.phrase.application;
+
+import com.travel.taipei.global.exception.BusinessException;
+import com.travel.taipei.global.exception.ErrorCode;
+import com.travel.taipei.phrase.domain.PhraseCategory;
+import com.travel.taipei.phrase.domain.PhraseRepository;
+import com.travel.taipei.phrase.interfaces.dto.PhraseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Locale;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PhraseService {
+
+    private final PhraseRepository phraseRepository;
+
+    public List<PhraseResponse> findAll() {
+        return phraseRepository.findAllByOrderByCategoryAscSortOrderAscIdAsc().stream()
+                .map(PhraseResponse::from)
+                .toList();
+    }
+
+    public List<PhraseResponse> findByCategory(String rawCategory) {
+        PhraseCategory category = parseCategory(rawCategory);
+        return phraseRepository.findByCategoryOrderBySortOrderAscIdAsc(category).stream()
+                .map(PhraseResponse::from)
+                .toList();
+    }
+
+    private PhraseCategory parseCategory(String rawCategory) {
+        if (rawCategory == null || rawCategory.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_CATEGORY);
+        }
+
+        String normalized = rawCategory.trim()
+                .replace("-", "_")
+                .replace(" ", "_")
+                .toUpperCase(Locale.ROOT);
+
+        try {
+            return PhraseCategory.valueOf(normalized);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_CATEGORY);
+        }
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/phrase/domain/Phrase.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/domain/Phrase.java
@@ -1,0 +1,50 @@
+package com.travel.taipei.phrase.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "phrase",
+        indexes = {
+                @Index(name = "idx_phrase_category_sort", columnList = "category, sort_order, id")
+        }
+)
+public class Phrase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PhraseCategory category;
+
+    @Column(nullable = false, length = 200)
+    private String korean;
+
+    @Column(nullable = false, length = 200)
+    private String chinese;
+
+    @Column(nullable = false, length = 200)
+    private String pronunciation;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+}

--- a/backend/src/main/java/com/travel/taipei/phrase/domain/PhraseCategory.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/domain/PhraseCategory.java
@@ -1,0 +1,10 @@
+package com.travel.taipei.phrase.domain;
+
+public enum PhraseCategory {
+    AIRPORT,
+    TRANSPORT,
+    HOTEL,
+    RESTAURANT,
+    SHOPPING,
+    EMERGENCY
+}

--- a/backend/src/main/java/com/travel/taipei/phrase/domain/PhraseRepository.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/domain/PhraseRepository.java
@@ -1,0 +1,12 @@
+package com.travel.taipei.phrase.domain;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhraseRepository extends JpaRepository<Phrase, Long> {
+
+    List<Phrase> findAllByOrderByCategoryAscSortOrderAscIdAsc();
+
+    List<Phrase> findByCategoryOrderBySortOrderAscIdAsc(PhraseCategory category);
+}

--- a/backend/src/main/java/com/travel/taipei/phrase/interfaces/PhraseController.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/interfaces/PhraseController.java
@@ -1,0 +1,30 @@
+package com.travel.taipei.phrase.interfaces;
+
+import com.travel.taipei.global.response.ApiResponse;
+import com.travel.taipei.phrase.application.PhraseService;
+import com.travel.taipei.phrase.interfaces.dto.PhraseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/phrases")
+@RequiredArgsConstructor
+public class PhraseController {
+
+    private final PhraseService phraseService;
+
+    @GetMapping
+    public ApiResponse<List<PhraseResponse>> findAll() {
+        return ApiResponse.ok(phraseService.findAll());
+    }
+
+    @GetMapping("/{category}")
+    public ApiResponse<List<PhraseResponse>> findByCategory(@PathVariable String category) {
+        return ApiResponse.ok(phraseService.findByCategory(category));
+    }
+}

--- a/backend/src/main/java/com/travel/taipei/phrase/interfaces/dto/PhraseResponse.java
+++ b/backend/src/main/java/com/travel/taipei/phrase/interfaces/dto/PhraseResponse.java
@@ -1,0 +1,23 @@
+package com.travel.taipei.phrase.interfaces.dto;
+
+import com.travel.taipei.phrase.domain.Phrase;
+
+import java.util.Locale;
+
+public record PhraseResponse(
+        Long id,
+        String category,
+        String korean,
+        String chinese,
+        String pronunciation
+) {
+    public static PhraseResponse from(Phrase phrase) {
+        return new PhraseResponse(
+                phrase.getId(),
+                phrase.getCategory().name().toLowerCase(Locale.ROOT),
+                phrase.getKorean(),
+                phrase.getChinese(),
+                phrase.getPronunciation()
+        );
+    }
+}

--- a/backend/src/main/resources/import.sql
+++ b/backend/src/main/resources/import.sql
@@ -1,0 +1,55 @@
+-- =============================================
+-- Phrase 초기 데이터
+-- =============================================
+
+-- AIRPORT (공항)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('AIRPORT', '수하물은 어디서 찾나요?', '行李在哪裡領取？', 'Xínglǐ zài nǎlǐ lǐngqǔ?', 1),
+('AIRPORT', '입국신고서를 작성해야 하나요?', '我需要填寫入境申報表嗎？', 'Wǒ xūyào tiánxiě rùjìng shēnbào biǎo ma?', 2),
+('AIRPORT', '환전소는 어디에 있나요?', '哪裡可以換錢？', 'Nǎlǐ kěyǐ huàn qián?', 3),
+('AIRPORT', '시내까지 어떻게 가나요?', '怎麼去市區？', 'Zěnme qù shìqū?', 4),
+('AIRPORT', '유심 카드는 어디서 구입하나요?', '哪裡可以買SIM卡？', 'Nǎlǐ kěyǐ mǎi SIM kǎ?', 5);
+
+-- TRANSPORT (교통)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('TRANSPORT', '~까지 가주세요.', '請帶我去～。', 'Qǐng dài wǒ qù ~.', 1),
+('TRANSPORT', '여기서 세워주세요.', '請在這裡停車。', 'Qǐng zài zhèlǐ tíngchē.', 2),
+('TRANSPORT', '이 역에서 내리면 되나요?', '我要在這站下車嗎？', 'Wǒ yào zài zhè zhàn xià chē ma?', 3),
+('TRANSPORT', '다음 역이 어디인가요?', '下一站是哪裡？', 'Xià yī zhàn shì nǎlǐ?', 4),
+('TRANSPORT', '편도로 한 장 주세요.', '請給我一張單程票。', 'Qǐng gěi wǒ yī zhāng dānchéng piào.', 5),
+('TRANSPORT', '이 버스가 ~에 가나요?', '這輛公車有去～嗎？', 'Zhè liàng gōngchē yǒu qù ~ ma?', 6);
+
+-- HOTEL (숙소)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('HOTEL', '체크인하고 싶어요.', '我想辦理入住。', 'Wǒ xiǎng bànlǐ rùzhù.', 1),
+('HOTEL', '체크아웃하고 싶어요.', '我想辦理退房。', 'Wǒ xiǎng bànlǐ tuìfáng.', 2),
+('HOTEL', '와이파이 비밀번호가 무엇인가요?', 'WiFi密碼是什麼？', 'WiFi mìmǎ shì shénme?', 3),
+('HOTEL', '수건을 더 주실 수 있나요?', '可以再給我一條毛巾嗎？', 'Kěyǐ zài gěi wǒ yī tiáo máojīn ma?', 4),
+('HOTEL', '짐을 맡길 수 있나요?', '我可以寄放行李嗎？', 'Wǒ kěyǐ jìfàng xínglǐ ma?', 5);
+
+-- RESTAURANT (음식점)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('RESTAURANT', '메뉴를 보여주세요.', '請給我看菜單。', 'Qǐng gěi wǒ kàn càidān.', 1),
+('RESTAURANT', '이걸로 주세요.', '我要這個。', 'Wǒ yào zhège.', 2),
+('RESTAURANT', '물 주세요.', '請給我水。', 'Qǐng gěi wǒ shuǐ.', 3),
+('RESTAURANT', '계산서 주세요.', '請給我帳單。', 'Qǐng gěi wǒ zhàngdān.', 4),
+('RESTAURANT', '맵지 않게 해주세요.', '請不要太辣。', 'Qǐng bùyào tài là.', 5),
+('RESTAURANT', '포장해 주실 수 있나요?', '可以打包嗎？', 'Kěyǐ dǎbāo ma?', 6);
+
+-- SHOPPING (쇼핑)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('SHOPPING', '얼마예요?', '這個多少錢？', 'Zhège duōshǎo qián?', 1),
+('SHOPPING', '깎아주실 수 있나요?', '可以便宜一點嗎？', 'Kěyǐ piányí yīdiǎn ma?', 2),
+('SHOPPING', '카드로 결제해도 되나요?', '可以刷卡嗎？', 'Kěyǐ shuā kǎ ma?', 3),
+('SHOPPING', '영수증 주세요.', '請給我收據。', 'Qǐng gěi wǒ shōujù.', 4),
+('SHOPPING', '이것을 입어볼 수 있나요?', '我可以試穿嗎？', 'Wǒ kěyǐ shì chuān ma?', 5),
+('SHOPPING', '다른 색상이 있나요?', '有其他顏色嗎？', 'Yǒu qítā yánsè ma?', 6);
+
+-- EMERGENCY (긴급상황)
+INSERT INTO phrase (category, korean, chinese, pronunciation, sort_order) VALUES
+('EMERGENCY', '도와주세요!', '救命啊！', 'Jiùmìng a!', 1),
+('EMERGENCY', '병원이 어디인가요?', '醫院在哪裡？', 'Yīyuàn zài nǎlǐ?', 2),
+('EMERGENCY', '경찰을 불러주세요.', '請叫警察。', 'Qǐng jiào jǐngchá.', 3),
+('EMERGENCY', '약국이 어디인가요?', '藥局在哪裡？', 'Yàojú zài nǎlǐ?', 4),
+('EMERGENCY', '여권을 잃어버렸어요.', '我的護照丟了。', 'Wǒ de hùzhào diū le.', 5),
+('EMERGENCY', '한국 대사관에 연락해야 해요.', '我需要聯絡韓國大使館。', 'Wǒ xūyào liánluò hánguó dàshǐguǎn.', 6);

--- a/backend/src/test/java/com/travel/taipei/phrase/application/PhraseServiceTest.java
+++ b/backend/src/test/java/com/travel/taipei/phrase/application/PhraseServiceTest.java
@@ -1,0 +1,91 @@
+package com.travel.taipei.phrase.application;
+
+import com.travel.taipei.global.exception.BusinessException;
+import com.travel.taipei.global.exception.ErrorCode;
+import com.travel.taipei.phrase.domain.Phrase;
+import com.travel.taipei.phrase.domain.PhraseCategory;
+import com.travel.taipei.phrase.domain.PhraseRepository;
+import com.travel.taipei.phrase.interfaces.dto.PhraseResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class PhraseServiceTest {
+
+    @Mock
+    private PhraseRepository phraseRepository;
+
+    @InjectMocks
+    private PhraseService phraseService;
+
+    @Test
+    void findAll_whenDataExists_returnsMappedList() {
+        Phrase phrase = phrase(1L, PhraseCategory.RESTAURANT, "물 주세요", "請給我水", "qing gei wo shui", 1);
+        given(phraseRepository.findAllByOrderByCategoryAscSortOrderAscIdAsc()).willReturn(List.of(phrase));
+
+        List<PhraseResponse> result = phraseService.findAll();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).category()).isEqualTo("restaurant");
+        assertThat(result.get(0).korean()).isEqualTo("물 주세요");
+    }
+
+    @Test
+    void findByCategory_whenCategoryIsValid_returnsMappedList() {
+        Phrase phrase = phrase(2L, PhraseCategory.HOTEL, "체크인하고 싶어요", "我想辦理入住", "wo xiang ban li ru zhu", 1);
+        given(phraseRepository.findByCategoryOrderBySortOrderAscIdAsc(PhraseCategory.HOTEL))
+                .willReturn(List.of(phrase));
+
+        List<PhraseResponse> result = phraseService.findByCategory("hotel");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).category()).isEqualTo("hotel");
+    }
+
+    @Test
+    void findByCategory_whenCategoryIsInvalid_throwsBusinessException() {
+        assertThatThrownBy(() -> phraseService.findByCategory("unknown"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.INVALID_CATEGORY.getMessage());
+
+        verifyNoInteractions(phraseRepository);
+    }
+
+    @Test
+    void findByCategory_whenNoData_returnsEmptyList() {
+        given(phraseRepository.findByCategoryOrderBySortOrderAscIdAsc(PhraseCategory.AIRPORT))
+                .willReturn(List.of());
+
+        List<PhraseResponse> result = phraseService.findByCategory("airport");
+
+        assertThat(result).isEmpty();
+    }
+
+    private Phrase phrase(
+            Long id,
+            PhraseCategory category,
+            String korean,
+            String chinese,
+            String pronunciation,
+            int sortOrder
+    ) {
+        return Phrase.builder()
+                .id(id)
+                .category(category)
+                .korean(korean)
+                .chinese(chinese)
+                .pronunciation(pronunciation)
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/travel/taipei/phrase/domain/PhraseRepositoryTest.java
+++ b/backend/src/test/java/com/travel/taipei/phrase/domain/PhraseRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.travel.taipei.phrase.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest(properties = {
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect"
+})
+class PhraseRepositoryTest {
+
+    @Autowired
+    private PhraseRepository phraseRepository;
+
+    @Test
+    void findAll_sortedByCategoryThenSortOrderThenId() {
+        phraseRepository.saveAll(List.of(
+            phrase(PhraseCategory.RESTAURANT, "물 주세요", 2),
+            phrase(PhraseCategory.AIRPORT,    "짐은 어디서 찾나요?", 1),
+            phrase(PhraseCategory.RESTAURANT, "메뉴 주세요", 1)
+        ));
+
+        List<Phrase> result = phraseRepository.findAllByOrderByCategoryAscSortOrderAscIdAsc();
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getCategory()).isEqualTo(PhraseCategory.AIRPORT);
+        assertThat(result.get(1).getSortOrder()).isEqualTo(1); // RESTAURANT sortOrder=1
+        assertThat(result.get(2).getSortOrder()).isEqualTo(2); // RESTAURANT sortOrder=2
+    }
+
+    @Test
+    void findByCategory_returnsOnlyMatchingCategory() {
+        phraseRepository.saveAll(List.of(
+            phrase(PhraseCategory.HOTEL,      "체크인해주세요", 1),
+            phrase(PhraseCategory.RESTAURANT, "물 주세요",     1)
+        ));
+
+        List<Phrase> result = phraseRepository.findByCategoryOrderBySortOrderAscIdAsc(PhraseCategory.HOTEL);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getCategory()).isEqualTo(PhraseCategory.HOTEL);
+    }
+
+    @Test
+    void findByCategory_sortedBySortOrderThenId() {
+        phraseRepository.saveAll(List.of(
+            phrase(PhraseCategory.SHOPPING, "영수증 주세요", 3),
+            phrase(PhraseCategory.SHOPPING, "얼마예요?",    1),
+            phrase(PhraseCategory.SHOPPING, "카드 되나요?", 2)
+        ));
+
+        List<Phrase> result = phraseRepository.findByCategoryOrderBySortOrderAscIdAsc(PhraseCategory.SHOPPING);
+
+        assertThat(result).extracting(Phrase::getSortOrder)
+                .containsExactly(1, 2, 3);
+    }
+
+    private Phrase phrase(PhraseCategory category, String korean, int sortOrder) {
+        return Phrase.builder()
+                .category(category)
+                .korean(korean)
+                .chinese("中文")
+                .pronunciation("pronunciation")
+                .sortOrder(sortOrder)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/travel/taipei/phrase/interfaces/PhraseControllerTest.java
+++ b/backend/src/test/java/com/travel/taipei/phrase/interfaces/PhraseControllerTest.java
@@ -1,0 +1,52 @@
+package com.travel.taipei.phrase.interfaces;
+
+import com.travel.taipei.global.exception.BusinessException;
+import com.travel.taipei.global.exception.ErrorCode;
+import com.travel.taipei.phrase.application.PhraseService;
+import com.travel.taipei.phrase.interfaces.dto.PhraseResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PhraseController.class)
+class PhraseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private PhraseService phraseService;
+
+    @Test
+    void findAll_whenRequestIsValid_returnsPhraseList() throws Exception {
+        given(phraseService.findAll()).willReturn(
+                List.of(new PhraseResponse(1L, "restaurant", "물 주세요", "請給我水", "qing gei wo shui"))
+        );
+
+        mockMvc.perform(get("/api/phrases"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].category").value("restaurant"))
+                .andExpect(jsonPath("$.data[0].korean").value("물 주세요"));
+    }
+
+    @Test
+    void findByCategory_whenCategoryIsInvalid_returnsBadRequest() throws Exception {
+        given(phraseService.findByCategory("invalid"))
+                .willThrow(new BusinessException(ErrorCode.INVALID_CATEGORY));
+
+        mockMvc.perform(get("/api/phrases/invalid"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value(ErrorCode.INVALID_CATEGORY.getMessage()));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
closes #3 

## 변경 사항
<!-- 무엇을 변경했는지 간결하게 -->
여행 중 필요한 대만어 회화(한국어 / 중국어 번체 / 발음)를 카테고리별로 제공는 API를 구현했습니다.

📁 구현 방향 
- `Phrase Entity` / `PhraseCategory Enum` / `PhraseRepository`
- `PhraseService` → 전체 조회 및 카테고리별 조회 
- `PhraseController` → GET /api/phrases, GET /api/phrases/{category}
- `PhraseResponse DTO`
- `import.sql` → 6개 카테고리 초기 데이터 (airport, transport, hotel, restaurant, shopping, emergency)
- `PhraseServiceTEst` / `PhraseControllerTest` / `PhraseRepositoryTest`

## 변경 유형

- [✓] feat: 새 기능
- [ ] fix: 버그 수정
- [ ] refactor: 리팩토링
- [ ] chore: 빌드/설정 변경
- [ ] docs: 문서

## 체크리스트
- [✓] 로컬에서 정상 동작 확인
- [✓] 테스트 추가/수정
- [ ] API 변경 시 프론트엔드 반영 확인